### PR TITLE
Enable post-checkout execution from any folder

### DIFF
--- a/.hooks/post-checkout
+++ b/.hooks/post-checkout
@@ -6,6 +6,8 @@
 # -----------------------------------------------------
 # Post-{commit,checkout,merge} hook for the gitinfo2 package
 #
+# Get the base directory of the repository
+repo_basedir=$(git rev-parse --show-toplevel)
 
 ## TODO: this works with git 2.20.1, we should find out which is the
 ## minimum version required
@@ -55,4 +57,4 @@ git --no-pager log -1 --date=short --decorate=short \
         refnames={%d},
         firsttagdescribe={$FIRSTTAG},
         reltag={$RELTAG}
-    ]{gitexinfo}" HEAD > .git/gitHeadInfo.gin
+    ]{gitexinfo}" HEAD > "${repo_basedir}/.git/gitHeadInfo.gin"


### PR DESCRIPTION
Use the base directory of the repository to allow the user to execute the script from any folder.