### PR TITLE
Redirecting output from git rev-list to /dev/null and enable post-merge/post-commit execution from any folder

### DIFF
--- a/.hooks/post-checkout
+++ b/.hooks/post-checkout
@@ -7,9 +7,9 @@
 # Post-{commit,checkout,merge} hook for the gitinfo2 package
 #
 
-## TODO: this works with git 2.20.1, we should find out which is the
+## TODO: this works with git 1.9.3, we should find out which is the
 ## minimum version required
-if git describe --tags "$(git rev-list --tags --max-count=1)" &>/dev/null; then
+if git describe --tags "$(git rev-list --tags --max-count=1 2> /dev/null)" &>/dev/null; then
     # we found at least a tag
 
     # Get the first tag found in the history from the current HEAD

--- a/.hooks/post-commit
+++ b/.hooks/post-commit
@@ -6,6 +6,7 @@
 # -----------------------------------------------------
 # Post-{commit,checkout,merge} hook for the gitinfo2 package
 #
+repo_basedir=$(git rev-parse --show-toplevel)
 
 ## TODO: this works with git 1.9.3, we should find out which is the
 ## minimum version required
@@ -55,4 +56,4 @@ git --no-pager log -1 --date=short --decorate=short \
         refnames={%d},
         firsttagdescribe={$FIRSTTAG},
         reltag={$RELTAG}
-    ]{gitexinfo}" HEAD > .git/gitHeadInfo.gin
+    ]{gitexinfo}" HEAD > "${repo_basedir}/.git/gitHeadInfo.gin"

--- a/.hooks/post-commit
+++ b/.hooks/post-commit
@@ -7,9 +7,9 @@
 # Post-{commit,checkout,merge} hook for the gitinfo2 package
 #
 
-## TODO: this works with git 2.20.1, we should find out which is the
+## TODO: this works with git 1.9.3, we should find out which is the
 ## minimum version required
-if git describe --tags "$(git rev-list --tags --max-count=1)" &>/dev/null; then
+if git describe --tags "$(git rev-list --tags --max-count=1 2> /dev/null)" &>/dev/null; then
     # we found at least a tag
 
     # Get the first tag found in the history from the current HEAD

--- a/.hooks/post-merge
+++ b/.hooks/post-merge
@@ -7,9 +7,9 @@
 # Post-{commit,checkout,merge} hook for the gitinfo2 package
 #
 
-## TODO: this works with git 2.20.1, we should find out which is the
+## TODO: this works with git 1.9.3, we should find out which is the
 ## minimum version required
-if git describe --tags "$(git rev-list --tags --max-count=1)" &>/dev/null; then
+if git describe --tags "$(git rev-list --tags --max-count=1 2> /dev/null)" &>/dev/null; then
     # we found at least a tag
 
     # Get the first tag found in the history from the current HEAD

--- a/.hooks/post-merge
+++ b/.hooks/post-merge
@@ -5,7 +5,8 @@
 # Please read gitinfo2.pdf for licencing and other details
 # -----------------------------------------------------
 # Post-{commit,checkout,merge} hook for the gitinfo2 package
-#
+# 
+repo_basedir=$(git rev-parse --show-toplevel)
 
 ## TODO: this works with git 1.9.3, we should find out which is the
 ## minimum version required
@@ -55,4 +56,4 @@ git --no-pager log -1 --date=short --decorate=short \
         refnames={%d},
         firsttagdescribe={$FIRSTTAG},
         reltag={$RELTAG}
-    ]{gitexinfo}" HEAD > .git/gitHeadInfo.gin
+    ]{gitexinfo}" HEAD > "${repo_basedir}/.git/gitHeadInfo.gin"


### PR DESCRIPTION
Tested with git 1.9.3.